### PR TITLE
Treat files under `benches/` as crate roots.

### DIFF
--- a/flycheck-rust.el
+++ b/flycheck-rust.el
@@ -50,6 +50,12 @@ REL-NAME is the file relative to the Cargo.toml file."
 REL-NAME is the file relative to the Cargo.toml file."
   (string-prefix-p "tests/" rel-name))
 
+(defun flycheck-rust-bench-p (rel-name)
+  "Whether REL-NAME denotes a bench.
+
+REL-NAME is the file relative to the Cargo.toml file."
+  (string-prefix-p "benches/" rel-name))
+
 (defun flycheck-rust-project-root ()
   "Get the project root for the current buffer.
 
@@ -72,6 +78,7 @@ Flycheck according to the Cargo project layout."
         ;; These are valid crate roots as by Cargo's layout
         (unless (or (flycheck-rust-executable-p rel-name)
                     (flycheck-rust-test-p rel-name)
+                    (flycheck-rust-bench-p rel-name)
                     (string= "src/lib.rs" rel-name))
           ;; For other files, the library is either the default library or the
           ;; executable


### PR DESCRIPTION
I'm not 100% sure whether this is correct, but it seems to be working fine for me.
