### PR TITLE
Consider crate binary if there's main.rs

### DIFF
--- a/flycheck-rust.el
+++ b/flycheck-rust.el
@@ -109,9 +109,10 @@ Flycheck according to the Cargo project layout."
                     (not (flycheck-rust-executable-p rel-name)))
         ;; Set the crate type
         (setq-local flycheck-rust-crate-type
-                    (if
-                        (file-exists-p
-                         (expand-file-name "src/main.rs" flycheck-rust-crate-root))
+                    (if (file-exists-p
+                         (expand-file-name
+                          "src/main.rs"
+                          (file-name-directory flycheck-rust-crate-root)))
                         "bin" "lib"))
         ;; Find build libraries
         (setq-local flycheck-rust-library-path

--- a/flycheck-rust.el
+++ b/flycheck-rust.el
@@ -109,7 +109,10 @@ Flycheck according to the Cargo project layout."
                     (not (flycheck-rust-executable-p rel-name)))
         ;; Set the crate type
         (setq-local flycheck-rust-crate-type
-                    (if (flycheck-rust-executable-p rel-name) "bin" "lib"))
+                    (if
+                        (file-exists-p
+                         (expand-file-name "src/main.rs" flycheck-rust-crate-root))
+                        "bin" "lib"))
         ;; Find build libraries
         (setq-local flycheck-rust-library-path
                     (list (expand-file-name "target/debug" root)


### PR DESCRIPTION
This way, at least simplest binary crate flychecking works with modules.

Currently, flycheck works ok in src/main.rs as it considers the crate binary while you're in that file. When working in src/foo.rs, which is a module foo of same binary crate, current setup's crate type guessing logic breaks, as modules are not accounted for at all.

This makes crate type guessing work in "global" fashion: now flycheck-rust-crate-type is "bin" in every file that belongs to this crate, if src/main.rs exists.