### PR TITLE
Fix binary crate detection.

### DIFF
--- a/flycheck-rust.el
+++ b/flycheck-rust.el
@@ -85,13 +85,13 @@ relative to the current file."
     (-when-let (exe-crate-dir (locate-dominating-file (buffer-file-name) "main.rs"))
       (expand-file-name "main.rs" exe-crate-dir))))
 
-(defun flycheck-rust-binary-crate-p (crate-root)
-  "Determine whether CRATE-ROOT is a binary crate.
+(defun flycheck-rust-binary-crate-p (project-root)
+  "Determine whether PROJECT-ROOT is a binary crate.
 
-CRATE-ROOT is the path to the root module of a crate.
+PROJECT-ROOT is the path to the root directory of the project.
 
-Return non-nil if CRATE-ROOT is a binary crate, nil otherwise."
-  (let ((root-dir (file-name-directory crate-root)))
+Return non-nil if PROJECT-ROOT is a binary crate, nil otherwise."
+  (let ((root-dir (file-name-directory project-root)))
     (file-exists-p (expand-file-name "src/main.rs" root-dir))))
 
 ;;;###autoload
@@ -105,21 +105,21 @@ Flycheck according to the Cargo project layout."
     (-when-let (root (flycheck-rust-project-root))
       (let ((rel-name (file-relative-name (buffer-file-name) root)))
         ;; These are valid crate roots as by Cargo's layout
-        (unless (or (flycheck-rust-executable-p rel-name)
-                    (flycheck-rust-test-p rel-name)
-                    (flycheck-rust-bench-p rel-name)
-                    (flycheck-rust-example-p rel-name)
-                    (string= "src/lib.rs" rel-name))
+        (if (or (flycheck-rust-executable-p rel-name)
+                (flycheck-rust-test-p rel-name)
+                (flycheck-rust-bench-p rel-name)
+                (flycheck-rust-example-p rel-name)
+                (string= "src/lib.rs" rel-name))
+            (setq-local flycheck-rust-crate-root rel-name)
           ;; For other files, the library is either the default library or the
           ;; executable
           (setq-local flycheck-rust-crate-root (flycheck-rust-find-crate-root)))
         ;; Check tests in libraries and integration tests
         (setq-local flycheck-rust-check-tests
                     (not (flycheck-rust-executable-p rel-name)))
-        ;; Set the crate type
         (setq-local flycheck-rust-crate-type
-                    (if (flycheck-rust-binary-crate-p flycheck-rust-crate-root)
-                        "bin" "lib"))
+                    (if (flycheck-rust-binary-crate-p root)
+                        "bin" "lib"))        ;; Set the crate type
         ;; Find build libraries
         (setq-local flycheck-rust-library-path
                     (list (expand-file-name "target/debug" root)


### PR DESCRIPTION
flycheck-rust-binary-crate-p should be passed project root, not the
crate root. Otherwise, detected crate root "src/main.rs" that gets
passed to the function makes root-dir "src/" and expand-file-name
produces "src/src/main.rs".

The correct way to detect this is to navigate from project root - the
directory where Cargo.toml is located.

Also, set flycheck-rust-crate-root in both cases: when one of predicates
match, the crate root is the rel-name of our current source. Otherwise,
we locate closest possible crate root and set that.

Fix #20.

An alternative to #21.