### PR TITLE
Add function to explain the error under point

### DIFF
--- a/flycheck-rust.el
+++ b/flycheck-rust.el
@@ -39,6 +39,10 @@
 ;; Note: You must run `cargo build` initially to install all dependencies.  If
 ;; you add new dependencies to `Cargo.toml` you need to run `cargo build`
 ;; again. Otherwise you will see spurious errors about missing crates.
+;;
+;; This extension also provides a convenience function for looking up
+;; explanations of the compiler error under point
+;; (`flycheck-rust-explain-error') that is not bound by default.
 
 ;;; Code:
 
@@ -158,6 +162,20 @@ Flycheck according to the Cargo project layout."
         (setq-local flycheck-rust-library-path
                     (list (expand-file-name "target/debug" root)
                           (expand-file-name "target/debug/deps" root)))))))
+
+;;;###autoload
+(defun flycheck-rust-explain-error (error-code)
+  "Explain ERROR-CODE by invoking `rustc --explain'.
+
+ERROR-CODE defaults to the code of the error under point."
+  (interactive
+   (list (let ((errors-at-point (flycheck-overlay-errors-at (point))))
+           (when (> (length errors-at-point) 0)
+             (flycheck-error-id (car errors-at-point))))))
+  (when error-code
+    (with-help-window (get-buffer-create "*rustc-explain*")
+      (with-current-buffer standard-output
+        (call-process "rustc" nil t nil "--explain" error-code)))))
 
 (provide 'flycheck-rust)
 


### PR DESCRIPTION
The rust compiler provides lengthy error explanations that would not be
practical to display at all times with flycheck.  However, we can
provide a convenience function to lookup the explanation for the error
under point.

This commit adds a function that calls `rustc --explain ID` with ID
being the code of the error under point.

I've _not_ bound the function to any key by default.  It would be useful to provide a default one for beginners, but that is up for discussion.  If we do add a default keybinding, it would be nice to also add a message to rust errors to signal that they can be explained by calling the function directly.  Along the lines of:

```
Type `C-c ! e` to see a detailed explanation
```

Also, if using an help window is the best way to achieve that.  It sure is convenient in my tests, but I'm open to better ideas.