### PR TITLE
Add a default keybinding for `flycheck-rust-explain-error`

### DIFF
--- a/flycheck-rust.el
+++ b/flycheck-rust.el
@@ -176,6 +176,9 @@ ERROR-CODE defaults to the code of the error under point."
       (with-current-buffer standard-output
         (call-process "rustc" nil t nil "--explain" error-code)))))
 
+;; Add a binding for explaining errors under the default flycheck prefix.
+(define-key flycheck-command-map "r" #'flycheck-rust-explain-error)
+
 (provide 'flycheck-rust)
 
 ;;; flycheck-rust.el ends here


### PR DESCRIPTION
#30 added a function to invoke `rustc --explain` on the error under point, but did not add a default keybinding for it.

The goal of this PR is to enhance the discoverability of this feature.

### Lost discoverability

When one uses `rustc` directly, the compiler suggests to use `rustc --explain` when there are errors that have associated explanations.  This is good for discoverability, and especially helpful for rust beginners.

This message also used to appear in the minibuffer as a `flycheck-error`: 

```
first mutable borrow occurs here [E0499]

run `rustc --explain E0499` to see a detailed explanation
```

but since the move to JSON output in flycheck/flycheck#1036 it doesn't anymore, because it's not included in the JSON as a message.  The same error now echoes:

```
first mutable borrow occurs here [E0499]
```

We have lost discoverability.  For users who are not already aware that they can use `rustc --explain` on the error code, this is unfortunate.

Now, adding a keybinding is a first step, but again, it's hidden unless you carefully read the changelog.

### Two proposals
I see two ways of adding the discoverability back:

1. Change the parser `flycheck-parse-rust` to insert a "hint" to use the binding to get an error explanation, like so:

```
Type `C-c ! r` to see a detailed explanation
```

2. Add an hyperlink to the error code.  This would be more subtle, but I think for Emacs users it would be rather intuitive that they can click on it, which would invoke the function as well.  Although, I don't know yet effect this change.  Is there a way to override `flycheck-error-format-message-and-id` in a checker?

### Where to place the keybinding addition

For the moment I added the keybinding in `flycheck-rust` itself by adding to `flycheck-command-map`.  I don't know if it's the best place and if it causes any side effects if the user redefines `flycheck-keymap-prefix` for instance.

### Bikeshedding

I used `C-c ! r` because it was available, but that's not a very good mnemonic... Unfortunately, `h`, `H` (**h**elp), `e` (**e**xplain) and `x` (e**x**plain) where all taken. 

Maybe `m` for "**m**ore info"? 