### PR TITLE
Remove `flycheck-rust-explain-error`

### DIFF
--- a/flycheck-rust.el
+++ b/flycheck-rust.el
@@ -39,10 +39,6 @@
 ;; Note: You must run `cargo build` initially to install all dependencies.  If
 ;; you add new dependencies to `Cargo.toml` you need to run `cargo build`
 ;; again. Otherwise you will see spurious errors about missing crates.
-;;
-;; This extension also provides a convenience function for looking up
-;; explanations of the compiler error under point
-;; (`flycheck-rust-explain-error') that is not bound by default.
 
 ;;; Code:
 
@@ -164,19 +160,6 @@ Flycheck according to the Cargo project layout."
         (setq-local flycheck-rust-library-path
                     (list (expand-file-name "target/debug" root)
                           (expand-file-name "target/debug/deps" root)))))))
-
-;;;###autoload
-(defun flycheck-rust-explain-error (error-code)
-  "Explain ERROR-CODE by invoking `rustc --explain'.
-
-ERROR-CODE defaults to the code of the error under point."
-  (interactive
-   (list (let ((errors-at-point (flycheck-overlay-errors-at (point))))
-           (and errors-at-point (flycheck-error-id (car errors-at-point))))))
-  (when error-code
-    (with-help-window (get-buffer-create "*rustc-explain*")
-      (with-current-buffer standard-output
-        (call-process "rustc" nil t nil "--explain" error-code)))))
 
 (provide 'flycheck-rust)
 


### PR DESCRIPTION
This functionality is now part of flycheck proper, through `flycheck-explain-error-at-point` (see flycheck/flycheck#1122).

As this was a function without any default keybinding, I don't see the harm in removing it now. 

@flycheck/rust do you agree?