### PR TITLE
Skip `flycheck-rust-setup` when cargo is missing

### DIFF
--- a/flycheck-rust.el
+++ b/flycheck-rust.el
@@ -131,35 +131,44 @@ Flycheck according to the Cargo project layout."
   (interactive)
   (when (buffer-file-name)
     (-when-let (root (flycheck-rust-project-root))
-      (pcase-let ((rel-name (file-relative-name (buffer-file-name) root))
-                  (`(,target-type . ,target-name) (flycheck-rust-find-target
+      ;; We should avoid raising any error in this function, as in combination
+      ;; with `global-flycheck-mode' it will render Emacs unusable (see
+      ;; https://github.com/flycheck/flycheck-rust/issues/40#issuecomment-253760883).
+      (if (not (funcall flycheck-executable-find "cargo"))
+          ;; We can still inform the user though
+          (message "flycheck-rust cannot find `cargo'.  Please \
+make sure that cargo is installed and on your PATH.  See \
+http://www.flycheck.org/en/latest/user/troubleshooting.html for \
+more information on setting your PATH with Emacs.")
+        (pcase-let ((rel-name (file-relative-name (buffer-file-name) root))
+                    (`(,target-type . ,target-name) (flycheck-rust-find-target
                                                      (buffer-file-name))))
-        ;; These are valid crate roots as by Cargo's layout
-        (if (or (flycheck-rust-executable-p rel-name)
-                (flycheck-rust-test-p rel-name)
-                (flycheck-rust-bench-p rel-name)
-                (flycheck-rust-example-p rel-name)
-                (string= "src/lib.rs" rel-name))
-            (setq-local flycheck-rust-crate-root rel-name)
-          ;; For other files, the library is either the default library or the
-          ;; executable
-          (setq-local flycheck-rust-crate-root (flycheck-rust-find-crate-root)))
-        ;; Check tests in libraries and integration tests
-        (setq-local flycheck-rust-check-tests
-                    (not (flycheck-rust-executable-p rel-name)))
-        ;; Set the crate type
-        (setq-local flycheck-rust-crate-type
-                    (if (string= target-type "bin")
-                        (progn
-                          ;; If it's binary target, we need to pass the binary
-                          ;; name
-                          (setq-local flycheck-rust-binary-name target-name)
-                          "bin")
-                      "lib"))
-        ;; Find build libraries
-        (setq-local flycheck-rust-library-path
-                    (list (expand-file-name "target/debug" root)
-                          (expand-file-name "target/debug/deps" root)))))))
+          ;; These are valid crate roots as by Cargo's layout
+          (if (or (flycheck-rust-executable-p rel-name)
+                  (flycheck-rust-test-p rel-name)
+                  (flycheck-rust-bench-p rel-name)
+                  (flycheck-rust-example-p rel-name)
+                  (string= "src/lib.rs" rel-name))
+              (setq-local flycheck-rust-crate-root rel-name)
+            ;; For other files, the library is either the default library or the
+            ;; executable
+            (setq-local flycheck-rust-crate-root (flycheck-rust-find-crate-root)))
+          ;; Check tests in libraries and integration tests
+          (setq-local flycheck-rust-check-tests
+                      (not (flycheck-rust-executable-p rel-name)))
+          ;; Set the crate type
+          (setq-local flycheck-rust-crate-type
+                      (if (string= target-type "bin")
+                          (progn
+                            ;; If it's binary target, we need to pass the binary
+                            ;; name
+                            (setq-local flycheck-rust-binary-name target-name)
+                            "bin")
+                        "lib"))
+          ;; Find build libraries
+          (setq-local flycheck-rust-library-path
+                      (list (expand-file-name "target/debug" root)
+                            (expand-file-name "target/debug/deps" root))))))))
 
 (provide 'flycheck-rust)
 


### PR DESCRIPTION
This commit adds a guard to abort setting any variable if cargo is missing.

Closes GH-40.