### PR TITLE
Fix ‘cargo metadata’ call for cargo 0.19.0-nightly

### DIFF
--- a/flycheck-rust.el
+++ b/flycheck-rust.el
@@ -80,9 +80,10 @@ root of the file hierarchy."
 
 MANIFEST is the path to the Cargo.toml file of the project.
 
-Calls `cargo metadata --no-deps --manifest MANIFEST', parses and
-collects the targets for the current workspace, and returns them
-in a list, or nil if no targets could be found."
+Calls `cargo metadata --no-deps --manifest-path MANIFEST
+--format-version 1', parses and collects the targets for the
+current workspace, and returns them in a list, or nil if no
+targets could be found."
   (let ((cargo (funcall flycheck-executable-find "cargo")))
     (unless cargo
       (user-error "flycheck-rust cannot find `cargo'.  Please \
@@ -95,7 +96,8 @@ more information on setting your PATH with Emacs."))
                              (with-temp-buffer
                                (call-process cargo nil t nil
                                              "metadata" "--no-deps"
-                                             "--manifest-path" manifest)
+                                             "--manifest-path" manifest
+                                             "--format-version" "1")
                                (goto-char (point-min))
                                (let ((json-array-type 'list))
                                  (json-read)))

--- a/flycheck-rust.el
+++ b/flycheck-rust.el
@@ -94,7 +94,7 @@ more information on setting your PATH with Emacs."))
     ;; targets.  We concatenate all targets, regardless of the package.
     (-when-let (packages (let-alist
                              (with-temp-buffer
-                               (call-process cargo nil t nil
+                               (call-process cargo nil '(t nil) nil
                                              "metadata" "--no-deps"
                                              "--manifest-path" manifest
                                              "--format-version" "1")


### PR DESCRIPTION
`flycheck-rust-get-cargo-targets` was failing in `json-read` because of a new warning emitted by cargo 0.19.0-nightly. Fix the warning, and also discard stderr so that future warnings don’t break things in the same way.