### PR TITLE
add custom build support

### DIFF
--- a/flycheck-rust.el
+++ b/flycheck-rust.el
@@ -150,7 +150,21 @@ description of the conventional Cargo project layout."
                                             (file-name-directory manifest)))))
             ;; If all else fails, just pick the first target
             (car targets))))
-      (let-alist target (cons (flycheck-rust-normalize-target-kind .kind) .name)))))
+      (let-alist target
+        ;; If target is 'custom-build', we search other target
+        (if (string= "custom-build" (car .kind))
+            (--> targets
+                 (-filter
+                  (lambda (target)
+                    (let-alist target
+                      (string-prefix-p
+                       (expand-file-name
+                        "src"
+                        (file-name-directory file-name))
+                       .src_path))) it)
+                 (car it)
+                 (let-alist it (cons (car .kind) .name)))
+          (cons (flycheck-rust-normalize-target-kind .kind) .name))))))
 
 (defun flycheck-rust-normalize-target-kind (kinds)
   "Return the normalized target name from KIND.

--- a/flycheck-rust.el
+++ b/flycheck-rust.el
@@ -151,7 +151,7 @@ description of the conventional Cargo project layout."
             ;; If all else fails, just pick the first target
             (car (car targets)))))
       (let-alist target
-        If target is 'custom-build', we search other target
+        ;; If target is 'custom-build', we search other target
         (if (string= "custom-build" (car .kind))
             (--> targets
                  ;; filtering same packages as current buffer

--- a/tests/build-script-test/Cargo.toml
+++ b/tests/build-script-test/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "build-script-test"
 version = "0.1.0"
-authors = ["kngwyu <yuji.kngw.80s.revive@gmail.com>"]
 
 [dependencies]
 

--- a/tests/build-script-test/Cargo.toml
+++ b/tests/build-script-test/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "build-script-test"
+version = "0.1.0"
+authors = ["kngwyu <yuji.kngw.80s.revive@gmail.com>"]
+
+[dependencies]
+
+[workspace]
+members = ["lib-test"]

--- a/tests/build-script-test/build.rs
+++ b/tests/build-script-test/build.rs
@@ -1,0 +1,4 @@
+fn main() {
+    let a = ;
+    println!("cargo:rustc-link-lib=bz2");
+}

--- a/tests/build-script-test/lib-test/Cargo.toml
+++ b/tests/build-script-test/lib-test/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "lib-test"
 version = "0.1.0"
-authors = ["kngwyu <yuji.kngw.80s.revive@gmail.com>"]
 
 [dependencies]

--- a/tests/build-script-test/lib-test/Cargo.toml
+++ b/tests/build-script-test/lib-test/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "lib-test"
+version = "0.1.0"
+authors = ["kngwyu <yuji.kngw.80s.revive@gmail.com>"]
+
+[dependencies]

--- a/tests/build-script-test/lib-test/build.rs
+++ b/tests/build-script-test/lib-test/build.rs
@@ -1,0 +1,6 @@
+fn main() {
+    let a = 0;
+    println!("cargo:rustc-link-lib=zzip");
+}
+
+

--- a/tests/build-script-test/lib-test/src/lib.rs
+++ b/tests/build-script-test/lib-test/src/lib.rs
@@ -1,0 +1,7 @@
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+        assert_eq!(2 + 2, 4);
+    }
+}

--- a/tests/build-script-test/src/main.rs
+++ b/tests/build-script-test/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}

--- a/tests/test-rust-setup.el
+++ b/tests/test-rust-setup.el
@@ -41,6 +41,9 @@
 (defun lib-crate-file (file-name)
   (expand-file-name file-name "tests/custom-lib-target"))
 
+(defun build-script-crate-file (file-name)
+  (expand-file-name file-name "tests/build-script-test"))
+
 (describe
  "`flycheck-rust-find-cargo-target' associates"
 
@@ -118,4 +121,14 @@
      (expect
       (car (flycheck-rust-find-cargo-target (lib-crate-file "src/lib.rs")))
       :to-equal "lib"))
+
+ (it "'build.rs' to any target in the same workspace member(parent)"
+     (expect
+      (flycheck-rust-find-cargo-target (build-script-crate-file "build.rs"))
+      :to-equal (cons "bin" "build-script-test")))
+
+ (it "'build.rs' to any target in the same workspace member(child)"
+     (expect
+      (flycheck-rust-find-cargo-target (build-script-crate-file "lib-test/build.rs"))
+      :to-equal (cons "lib" "lib-test")))
  )

--- a/tests/test-rust-setup.el
+++ b/tests/test-rust-setup.el
@@ -122,12 +122,12 @@
       (car (flycheck-rust-find-cargo-target (lib-crate-file "src/lib.rs")))
       :to-equal "lib"))
 
- (it "'build.rs' to any target in the same workspace member(parent)"
+ (it "'build.rs' to any target in the same workspace member (parent)"
      (expect
       (flycheck-rust-find-cargo-target (build-script-crate-file "build.rs"))
       :to-equal (cons "bin" "build-script-test")))
 
- (it "'build.rs' to any target in the same workspace member(child)"
+ (it "'build.rs' to any target in the same workspace member (child)"
      (expect
       (flycheck-rust-find-cargo-target (build-script-crate-file "lib-test/build.rs"))
       :to-equal (cons "lib" "lib-test")))


### PR DESCRIPTION
When we're editing 'build.rs', it's target kind in cargo metadata is 'custom-build', which we can not use as build arguments.
So flycheck tries to run command like `cargo test --custom-build ..` and fails.
To solve this, when cargo metadata returns that current buffer is 'custom-build' target, we have to search other target.

Here's the repository I used for test.
https://gitlab.com/kngwyu/flycheck-rust-buildscript-test